### PR TITLE
fix #182 (build under java 8): CompactSyntax needs parameters

### DIFF
--- a/mod/rng-parse/src/main/com/thaiopensource/relaxng/parse/compact/CompactSyntax.jj
+++ b/mod/rng-parse/src/main/com/thaiopensource/relaxng/parse/compact/CompactSyntax.jj
@@ -990,7 +990,7 @@ void Include(GrammarSection<Pattern, Location, ElementAnnotation, CommentListImp
   Token t;
   String href;
   String ns;
-  Include include = section.makeInclude();
+  Include<Pattern, Location, ElementAnnotation, CommentListImpl, AnnotationsImpl> include = section.makeInclude();
 }
 {
   t = "include" href = Literal()


### PR DESCRIPTION
Just converting @pterjan's patch into a pull request to make it easier to apply.  Builds under both Java 7 and Java 8.