### PR TITLE
Correctly handle BCE leap years in call to GregorianCalendar isLeapYear

### DIFF
--- a/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/DateTimeDatatype.java
+++ b/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/DateTimeDatatype.java
@@ -252,6 +252,9 @@ class DateTimeDatatype extends RegexDatatype implements OrderRelation {
     month -= 1;
     cal.set(year, month, day, hours, minutes, seconds);
     cal.set(Calendar.MILLISECOND, milliseconds);
+    if (negative) {
+      year = -(year - 1);
+    }
     checkDate(cal.isLeapYear(year), month, day); // for GCJ
     return cal.getTime();
   }

--- a/mod/xsd-datatype/test/xsdtest.xml
+++ b/mod/xsd-datatype/test/xsdtest.xml
@@ -214,6 +214,12 @@
 <datatype name="date">
 <valid>1886-12-01</valid>
 <valid>1886-12-01Z</valid>
+<valid>0004-02-29</valid>
+<valid>-0001-02-29</valid>
+<valid>-0257-02-29</valid>
+<invalid>0003-02-29</invalid>
+<invalid>-0257-02-30</invalid>
+<invalid>-0258-02-29</invalid>
 <lessThan>
   <value>1066-12-31</value>
   <value>1900-01-01</value>


### PR DESCRIPTION
Under a reasonable interpretation of the XSD 1.0 Second Edition spec, BCE leap years should still be valid. `GregorianCalendar.isLeapYear()` expects BCE years to be negative and start at zero.

See also discussion at sosol/sosol#114 and TEIC/TEI#1344.
