### PR TITLE
Travis: Add openjdk8, remove openjdk6 and oraclejdk7 at least for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: java
 
 jdk:
-  - openjdk6
+  # https://github.com/travis-ci/travis-ci/issues/8199
+  #- openjdk6
   - openjdk7
-  - oraclejdk7
+  - openjdk8
+  # https://github.com/travis-ci/travis-ci/issues/7884
+  #- oraclejdk7
   - oraclejdk8
 
 script:


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/7884
https://github.com/travis-ci/travis-ci/issues/8199