### PR TITLE
Attempt to add support for xs:untypedAtomic and xs:anyAtomicType

### DIFF
--- a/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/AnyAtomicTypeDatatype.java
+++ b/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/AnyAtomicTypeDatatype.java
@@ -1,0 +1,7 @@
+package com.thaiopensource.datatype.xsd;
+
+class AnyAtomicTypeDatatype extends TokenDatatype {
+  AnyAtomicTypeDatatype() {
+    super(WHITE_SPACE_PRESERVE);
+  }
+}

--- a/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/DatatypeLibraryImpl.java
+++ b/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/DatatypeLibraryImpl.java
@@ -36,6 +36,8 @@ public class DatatypeLibraryImpl implements DatatypeLibrary {
     typeMap.put("normalizedString", new CdataDatatype());
     typeMap.put("token", new TokenDatatype());
     typeMap.put("boolean", new BooleanDatatype());
+    typeMap.put("untypedAtomic", new UntypedAtomicDatatype());
+    typeMap.put("anyAtomicType", new AnyAtomicTypeDatatype());
 
     DatatypeBase decimalType = new DecimalDatatype();
     typeMap.put("decimal", decimalType);

--- a/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/UntypedAtomicDatatype.java
+++ b/mod/xsd-datatype/src/main/com/thaiopensource/datatype/xsd/UntypedAtomicDatatype.java
@@ -1,0 +1,7 @@
+package com.thaiopensource.datatype.xsd;
+
+class UntypedAtomicDatatype extends TokenDatatype {
+  UntypedAtomicDatatype() {
+    super(WHITE_SPACE_PRESERVE);
+  }
+}

--- a/mod/xsd-datatype/test/xsdtest.xml
+++ b/mod/xsd-datatype/test/xsdtest.xml
@@ -803,4 +803,10 @@ B EEF </value>
 "
 > foo bar </valid>
 </datatype>
+<datatype name="untypedAtomic">
+<valid>any thing at all!</valid>
+</datatype>
+<datatype name="anyAtomicType">
+<valid>any thing at all!</valid>
+</datatype>
 </xsdtest>


### PR DESCRIPTION
Right. In the spirit of being helpful, I've made an admittedly somewhat crude stab at supporting `xs:untypedAtomic` and `xs:anyAtomicType`. Like `xs:string`, they accept anything. I think that's all that needs to be done from a validation perspective.

I added a couple of tests and the resulting jars work validating the real-world use case where I was attempting to declare an attribute as being any atomic type.

This PR would fix #229 if it was merged.