### PR TITLE
Fix NullPointerException when namespace URI is null.

### DIFF
--- a/mod/rng-schema/src/main/com/thaiopensource/relaxng/output/rnc/Output.java
+++ b/mod/rng-schema/src/main/com/thaiopensource/relaxng/output/rnc/Output.java
@@ -1222,7 +1222,7 @@ class Output {
       if (!prefix.equals("")) {
         String ns = context.getNamespace(prefix);
         if (ns != null && !ns.equals(SchemaBuilder.INHERIT_NS)
-            && !nsb.getNamespaceUri(prefix).equals(ns))
+            && !ns.equals(nsb.getNamespaceUri(prefix)))
           er.warning("annotation_inconsistent_binding", prefix, ns, loc);
       }
     }


### PR DESCRIPTION
Inverting the equality avoids exception because ns is checked as not null.