### PR TITLE
Fix missing format string for column argument

### DIFF
--- a/mod/util/src/main/com/thaiopensource/xml/sax/resources/Messages.properties
+++ b/mod/util/src/main/com/thaiopensource/xml/sax/resources/Messages.properties
@@ -17,7 +17,7 @@ locator_system_id_line_number_column_number={0}:{1,number,#}:{2,number,#}: \
 locator_line_number=(unknown file):{0,number,#}: \
 
 # constructs string used as second argument of fatal, error, warning
-locator_line_number_column_number=(unknown file):{0,number,#}: \
+locator_line_number_column_number=(unknown file):{0,number,#}:{1,number,#}: \
 
 # first argument is class name; second argument is detail message
 exception=exception "{0}" thrown: {1}


### PR DESCRIPTION
This prevented column numbers being reported when a system ID wasn't available, i.e. when using an `InputSource` constructed directly from an `InputStream`.