### PR TITLE
Get the start pattern of PatternSchema

### DIFF
--- a/mod/rng-validate/src/main/com/thaiopensource/validate/rng/impl/PatternSchema.java
+++ b/mod/rng-validate/src/main/com/thaiopensource/validate/rng/impl/PatternSchema.java
@@ -18,6 +18,15 @@ public class PatternSchema extends AbstractSchema {
     this.spb = spb;
     this.start = start;
   }
+ 
+  /**
+   * Returns the pattern start.
+   * 
+   * @return the pattern start.
+   */
+  public Pattern getStart() {
+    return start;
+  }
 
   public Validator createValidator(PropertyMap properties) {
     ErrorHandler eh = properties.get(ValidateProperty.ERROR_HANDLER);

--- a/mod/validate/src/main/com/thaiopensource/validate/CombineSchema.java
+++ b/mod/validate/src/main/com/thaiopensource/validate/CombineSchema.java
@@ -1,9 +1,6 @@
 package com.thaiopensource.validate;
 
 import com.thaiopensource.util.PropertyMap;
-import com.thaiopensource.validate.AbstractSchema;
-import com.thaiopensource.validate.Schema;
-import com.thaiopensource.validate.Validator;
 
 public class CombineSchema extends AbstractSchema {
   private final Schema schema1;
@@ -15,6 +12,14 @@ public class CombineSchema extends AbstractSchema {
     this.schema2 = schema2;
   }
 
+  public Schema getSchema1() {
+    return schema1;
+  }
+  
+  public Schema getSchema2() {
+    return schema2;
+  }
+  
   public Validator createValidator(PropertyMap properties) {
     return new CombineValidator(schema1.createValidator(properties),
                                 schema2.createValidator(properties));


### PR DESCRIPTION
This PR provides the capability to get the start pattern when the RelaxNG Schema is loaded. 

In my case, I need to get the start pattern to support XML completion based on RelaxNG. 

The CombineSchema is updated too to get the 2 Schemas and in this case we can get the first Schema, cast it to PatternSchema to get the start pattern.