### PR TITLE
Remove configuration of XSLT version in Saxon

### DIFF
--- a/mod/schematron/src/main/com/thaiopensource/validate/schematron/NewSaxonSchemaReaderFactory.java
+++ b/mod/schematron/src/main/com/thaiopensource/validate/schematron/NewSaxonSchemaReaderFactory.java
@@ -12,11 +12,6 @@ public class NewSaxonSchemaReaderFactory extends SchematronSchemaReaderFactory {
   }
 
   public void initTransformerFactory(TransformerFactory factory) {
-    try {
-      factory.setAttribute(FeatureKeys.XSLT_VERSION, "2.0");
-    } catch (IllegalArgumentException e) {
-      // The old Saxon 9 (pre HE/PE/EE) throws this exception.
-    }
     factory.setAttribute(FeatureKeys.LINE_NUMBERING, Boolean.TRUE);
     factory.setAttribute(FeatureKeys.VERSION_WARNING, Boolean.FALSE);
   }


### PR DESCRIPTION
Setting the "XSLT_VERSION" feature on Saxon's `TransformerFactory` issued a warning on recent Saxon version (9.8+).

According to @michaelkay:

> At one time (before 3.0 was finalised) Saxon had the option to operate
> as either a 2.0 or a 3.0 conformant processor. If you selected 2.0 (in
> the API), then we tried hard to suppress all 3.0 features such as new
> functions, xsl:iterate, etc. Simply setting version="2.0" in the
> stylesheet doesn't have this effect (3.0 features will still work, so
> you don't pass the conformance tests for 2.0). At some later date we
> decided we would no longer have a 2.0-conformant mode: if you request
> 2.0, we fall back to 3.0, so you get the 3.0 features whether you like
> it or not. We made this decision because the level of backwards
> compatibility between 2.0 and 3.0 is very high, so pretty well all
> non-error stylesheets will run unchanged.

This commit removes the code setting the "XSLT_VERSION" feature.

Fix #277.