### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,20 @@ on:
   pull_request:
 jobs:
   test:
+    strategy:
+      matrix:
+        jdk: [ 8, 11, 17, 21 ] # lts releases
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-      - name: Set up JDK 8
+      - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: ${{ matrix.jdk }}
       - name: Build modules
         run: ./ant modbuild
       - name: Build JAR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,11 @@ jobs:
         run: ./ant ant-jar
       - name: Validate
         run: ./ant validate
+      - name: Build Jing distribution
+        run: ./ant jing-dist
+      - name: Build Trang distribution
+        run: ./ant trang-dist
+      - name: Build DTDinst distribution
+        run: ./ant dtdinst-dist
+      - name: Build website
+        run: ./ant website

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Build modules
+        run: ./ant modbuild
+      - name: Build JAR
+        run: ./ant ant-jar
+      - name: Validate
+        run: ./ant validate


### PR DESCRIPTION
It seems the project no longer uses Travis. This PR adds a test GitHub Actions workflow that

1. Generates module build scripts
2. Builds JAR file
3. Runs validation target
4. Builds Jing distribution
5. Builds Trang distribution
6. Builds DTDinst distribution
7. Builds website

While just running the `dist` target would run all the preceding targets, running them separately makes it easier to track at which point the build has failed.

See https://github.com/jelovirt/jing-trang/actions/workflows/test.yml to see how workflow looks in GitHub UI.